### PR TITLE
Update Alpine image to 3.18.5 and reduce installed packages

### DIFF
--- a/images/alpine3.18/Dockerfile
+++ b/images/alpine3.18/Dockerfile
@@ -1,16 +1,14 @@
 # SPDX-FileCopyrightText: 2023 bootloose authors
 # SPDX-License-Identifier: Apache-2.0
-FROM alpine:3.18.3
+FROM alpine:3.18.5
 
 RUN apk add --no-cache \
   alpine-base \
-  dbus \
   openssh-server \
-  bash \
-  shadow \
   doas \
   curl \
   && rc-update add syslog boot \
+  && rc-update add machine-id boot \
   && rc-update add sshd default \
   && rc-update add local default \
 # disable ttys
@@ -23,19 +21,5 @@ RUN apk add --no-cache \
   && echo permit :wheel >> /etc/doas.d/doas.conf \
   && echo permit nopass keepenv root >> /etc/doas.d/doas.conf
 
-# This container image doesn't have locales installed. Disable forwarding the
-# user locale env variables or we get warnings such as:
-#  bash: warning: setlocale: LC_ALL: cannot change locale
-RUN sed -i -e 's/^AcceptEnv LANG LC_\*$/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config
-
-# Add entry script
-RUN rm -f /etc/machine-id; echo -e '#!/bin/sh\n[ -f "/var/lib/dbus/machine-id" ] && rm /var/lib/dbus/machine-id\ndbus-uuidgen --ensure=/var/lib/dbus/machine-id\nexec "$@"' > /entry.sh \
-    && chmod +x /entry.sh
-
-# https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
-STOPSIGNAL SIGRTMIN+3
-
-# Set the entry script as the entry point
-ENTRYPOINT ["/entry.sh"]
-
-CMD ["/bin/bash"]
+# Start a shell if no command is given, otherwise exec the command verbatim.
+ENTRYPOINT ["/bin/sh", "-c", "[ $# -gt 0 ] || set -- /bin/sh; exec \"$@\"", "--"]


### PR DESCRIPTION
Removed dbus in favor of using the already provided machine-id OpenRC service. Remove shadow and bash, as the test suite passes without them. Remove the systemd specific signal.