### PR TITLE
Separate publish-image workflow

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2023 bootloose authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Publish Image
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        description: The image to be published.
+      tag:
+        type: string
+        description: The tag to use for the image. Defaults to :latest if not specified.
+        required: false
+        default: latest
+    secrets:
+      QUAY_USERNAME:
+        description: The username used to log in to Quay.io.
+        required: true
+      QUAY_PASSWORD:
+        description: The password used to log in to Quay.io.
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      image:
+        type: string
+        description: The image to be published.
+      tag:
+        type: string
+        description: The tag to use for the image. Defaults to :latest if not specified.
+        required: false
+        default: latest
+
+jobs:
+  publish_image:
+    needs: prepare
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: List image platforms
+      id: list-platforms
+      run: |
+        platforms=$(make -s -C images "${{ inputs.image }}-platforms")
+        echo "platforms=${platforms}" >> $GITHUB_OUTPUT
+
+    - name: Login to Quay
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ steps.list-platforms.outputs.platforms }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Cache Buildx Docker layers
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx
+
+    - name: Build ${{ inputs.image }}
+      uses: docker/build-push-action@v5
+      with:
+        platforms: ${{ steps.list-platforms.outputs.platforms }}
+        push: true
+        tags: |
+          quay.io/k0sproject/bootloose-${{ inputs.image }}:${{ inputs.tag }}
+        context: images/${{ inputs.image }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 bootloose authors
+# SPDX-License-Identifier: Apache-2.0
+
 name: Publish Images
 
 on:
@@ -58,50 +61,15 @@ jobs:
 
   publish_images:
     needs: prepare
-    runs-on: ubuntu-20.04
     strategy:
-      matrix: 
+      matrix:
         image: ${{fromJson(needs.prepare.outputs.images)}}
       fail-fast: false
 
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: List image platforms
-      id: list-platforms
-      run: |
-        platforms=$(make -s -C images "${{ matrix.image }}-platforms")
-        echo "platforms=${platforms}" >> $GITHUB_OUTPUT
-    
-    - name: Login to Quay
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: ${{ steps.list-platforms.outputs.platforms }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Cache Buildx Docker layers
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx
-
-    - name: Build ${{ matrix.image }}
-      uses: docker/build-push-action@v5
-      with:
-        platforms: ${{ steps.list-platforms.outputs.platforms }}
-        push: true
-        tags: |
-          quay.io/k0sproject/bootloose-${{ matrix.image }}:${{ needs.prepare.outputs.tag }}
-        context: images/${{ matrix.image }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+    uses: ./.github/workflows/publish-image.yaml
+    with:
+      image: ${{ matrix.image }}
+      tag: ${{ needs.prepare.outputs.tag }}
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Factor out the matrix build in its own workflow. Allow for the workflow to be triggered manually. This allows individual images to be published manually.