### PR TITLE
Use GitHub API to list images

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -11,53 +11,50 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The tag to use for images. Defaults to :latest if not specified.'
+        description: The tag to use for images. Defaults to the tag name if publishing a tag, "latest" otherwise.
         required: false
-        default: 'latest'
 
 jobs:
   prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       tag: ${{ steps.set-tag.outputs.tag }}
-      images: ${{ steps.set-images.outputs.images }}
+      images: ${{ steps.list-images.outputs.images }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Tag from dispatch
-      if: github.event_name == 'workflow_dispatch'
-      run: echo "tag=${{ github.event.inputs.tag || 'latest' }}" >> $GITHUB_ENV
-    
-    - name: Tag from ref
-      if: startsWith(github.ref, 'refs/tags/')
-      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Set tag
+        id: set-tag
+        env:
+          TAG: "${{ inputs.tag }}"
+        run: |
+          if [ -z "$TAG" ] && [[ "$GITHUB_REF" = refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo tag="${TAG-latest}" >>"$GITHUB_OUTPUT"
 
-    - name: Default tag
-      if: github.event_name != 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
-      run: echo "tag=latest" >> $GITHUB_ENV
-
-    - name: Set tag
-      id: set-tag
-      run: echo "tag=${tag}" >> $GITHUB_OUTPUT
-
-    - name: List all images
-      if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-      run: |
-        image_dirs=$(find images -name 'Dockerfile' -exec dirname {} \; | xargs -n 1 basename | tr '\n' ' ')
-        echo "image_dirs=$image_dirs" >> $GITHUB_ENV
-
-    - name: List changed images
-      if: github.event_name != 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
-      run: |
-        image_dirs=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep 'images/.*/Dockerfile' | awk -F/ '{print $(NF-1)}' | tr '\n' ' ' | sed 's/ $//')
-        echo "image_dirs=$image_dirs" >> $GITHUB_ENV
-
-    - name: Set image list
-      id: set-images
-      run: |
-        image_dirs_json=$(echo "$image_dirs" | jq -R -c 'split(" ") | map(select(. != ""))')
-        echo "images=${image_dirs_json}}" >> $GITHUB_OUTPUT
+      - name: List images
+        id: list-images
+        env:
+          BEFORE: "${{ github.event.before }}"
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = workflow_dispatch ] || [[ "$GITHUB_REF" = refs/tags/* ]]; then
+            gh api /repos/{owner}/{repo}/git/trees/"${GITHUB_SHA}"?recursive=1 --paginate --jq '
+              [ .tree[]
+                | select(.type == "blob")
+                | .path
+                | split("/")
+                | select(length == 3 and .[0] == "images" and .[2] == "Dockerfile")
+                | .[1]
+              ] | unique | "images=" + tojson
+            ' >>"$GITHUB_OUTPUT"
+          else
+            gh api /repos/{owner}/{repo}/compare/"${BEFORE}...${GITHUB_SHA}" --paginate --jq '
+              [ .files[].filename
+                | split("/")
+                | select(length == 3 and .[0] == "images" and .[2] == "Dockerfile")
+                | .[1]
+              ] | unique | "images=" + tojson
+            ' >>"$GITHUB_OUTPUT"
+          fi
 
   publish_images:
     needs: prepare


### PR DESCRIPTION
The previous solution required a full checkout of the repo in order to determine which images had changed. There was a subtle bug in there, as the checkout was not done with full depth. Only the most recent commit was fetched. This led to situations where the image list generation failed with "bad object" errors.

There's a more straightforward approach using the GitHub API and the gh CLI. It allows for easy fetching of diffs and massaging them via jq queries. The same can be done to get the file list of a repository, eliminating the need for a checkout in both cases.