### PR TITLE
Add GH_REPO to workflow step

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -38,6 +38,7 @@ jobs:
         id: list-images
         env:
           BEFORE: "${{ github.event.before }}"
+          GH_REPO: "${{ github.repository }}"
           GH_TOKEN: "${{ github.token }}"
         run: |
           if [ "$GITHUB_EVENT_NAME" = workflow_dispatch ] || [[ "$GITHUB_REF" = refs/tags/* ]]; then


### PR DESCRIPTION
This unlocks the gh CLI usage.