### PR TITLE
Don't mount cgroups read-only for cgroups V1

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -312,7 +312,7 @@ func (c *Cluster) createMachineRunArgs(machine *Machine, name string, i int) []s
 			"-v", "/sys/fs/cgroup:/sys/fs/cgroup:rw")
 
 	} else {
-		runArgs = append(runArgs, "-v", "/sys/fs/cgroup:/sys/fs/cgroup:ro")
+		runArgs = append(runArgs, "-v", "/sys/fs/cgroup:/sys/fs/cgroup")
 	}
 
 	for _, volume := range machine.spec.Volumes {


### PR DESCRIPTION
Since Docker 25, read-only mounts will be recursively read-only. That spoils the fun for systemd.