### PR TITLE
Retire ubuntu-20.04 CI runners

### DIFF
--- a/.github/workflows/check-copyright-boilerplate.yaml
+++ b/.github/workflows/check-copyright-boilerplate.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   check:
     name: DCO check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout k0s
         uses: actions/checkout@v4

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       hash: ${{ steps.set-hash.outputs.hash }}
@@ -48,7 +48,7 @@ jobs:
 
   run_tests:
     needs: prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
       fail-fast: false

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   publish_image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   prepare:
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag-name.outputs.tag }}
     steps:
@@ -22,7 +22,7 @@ jobs:
   publish_binaries:
     if: startsWith(github.ref, 'refs/tags/')
     needs: prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
CI fails because ubuntu-20.04 runners are not available anymore.
